### PR TITLE
Parsing .env sooner to possibly override env vars before usage

### DIFF
--- a/fwd
+++ b/fwd
@@ -6,6 +6,10 @@ export ASUSER=${ASUSER:-$UID}
 export COMPOSE_EXEC_FLAGS=${COMPOSE_EXEC_FLAGS:-""}
 export SSH_KEY_PATH=${SSH_KEY_PATH:-"$HOME/.ssh/id_rsa"}
 
+if [ -f .env ]; then
+    source .env
+fi
+
 # Is the environment running
 PSRESULT="$(docker-compose ps -q)"
 if [ ! -z "$PSRESULT" ]; then
@@ -30,10 +34,6 @@ QA_RUN="docker run --rm -it \
 if [ $# -eq 0 ]; then
     $COMPOSE ps
     exit 0
-fi
-
-if [ -f .env ]; then
-    source .env
 fi
 
 if [ "$1" == "init" ]; then


### PR DESCRIPTION
So we can for example do this on our `.env`:

```
COMPOSE_EXEC_FLAGS="--env DOMAIN=${DOMAIN}"
COMPOSE_API_VERSION=1.25
```

And these variables will be applied properly when using `./fwd` without the need to change it directly.

This is a real use case for a project where we always need to pass in what domain is the target (multi tenant application) and so we want to pass in such flags without the need to change `fwd` itself.