### PR TITLE
Remove -v argument from yarn

### DIFF
--- a/app/Commands/Yarn.php
+++ b/app/Commands/Yarn.php
@@ -37,14 +37,4 @@ class Yarn extends Command
             $this->getArgs()
         );
     }
-
-    /**
-     * Get default args when empty.
-     *
-     * @return string
-     */
-    public function getDefaultArgs(): string
-    {
-        return '-v';
-    }
 }

--- a/tests/Feature/YarnTest.php
+++ b/tests/Feature/YarnTest.php
@@ -10,7 +10,7 @@ class YarnTest extends TestCase
     {
         $this->artisan('yarn')->assertExitCode(0);
 
-        $this->assertDockerRun('fireworkweb/node:alpine yarn -v');
+        $this->assertDockerRun('fireworkweb/node:alpine yarn');
     }
 
     public function testYarnCustom()


### PR DESCRIPTION
When running `fwd yarn`, it should just execute `yarn`, since it will execute `install` by default.