### PR TITLE
start --all --services new options

### DIFF
--- a/.fwd
+++ b/.fwd
@@ -38,6 +38,8 @@ FWD_IMAGE_DATABASE="mysql:5.7"
 FWD_IMAGE_NODE_QA="fireworkweb/node:qa"
 FWD_IMAGE_PHP_QA="jakzal/phpqa:alpine"
 
+FWD_START_DEFAULT_SERVICES="mysql redis app http"
+
 # Database
 DB_DATABASE="docker"
 DB_USERNAME="docker"

--- a/app/Commands/Start.php
+++ b/app/Commands/Start.php
@@ -13,7 +13,9 @@ class Start extends Command
      */
     protected $signature = 'start
                             {--no-wait : Do not wait for Docker and MySQL to become available}
-                            {--timeout=60 : The number of seconds to wait}';
+                            {--timeout=60 : The number of seconds to wait}
+                            {--all : Start all services}
+                            {--services= : The services from docker-compose.yml to be started}';
 
     /**
      * The description of the command.
@@ -31,6 +33,12 @@ class Start extends Command
     {
         $timeout = ! $this->option('no-wait') ? $this->option('timeout') : 0;
 
-        return StartTask::make($this)->timeout($timeout)->run();
+        $task = StartTask::make($this)->timeout($timeout);
+
+        if (! $this->option('all')) {
+            $task->services((string) $this->option('services'));
+        }
+
+        return $task->run();
     }
 }

--- a/app/Tasks/Start.php
+++ b/app/Tasks/Start.php
@@ -12,6 +12,9 @@ class Start extends Task
     /** @var int $timeout */
     protected $timeout = 60; // seconds
 
+    /** @var string $services */
+    protected $services;
+
     public function run(...$args): int
     {
         return $this->runCallables([
@@ -21,7 +24,14 @@ class Start extends Task
         ]);
     }
 
-    public function timeout(int $timeout)
+    public function services(string $services) : self
+    {
+        $this->services = $services;
+
+        return $this;
+    }
+
+    public function timeout(int $timeout) : self
     {
         $this->timeout = $timeout;
 
@@ -75,8 +85,12 @@ class Start extends Task
     public function dockerComposeUpD()
     {
         return $this->runTask('Starting fwd', function () {
+            $services = ! is_null($this->services)
+                ? ($this->services ?: env('FWD_START_DEFAULT_SERVICES'))
+                : null;
+
             return $this->runCommandWithoutOutput(
-                DockerCompose::make('up', '-d'),
+                DockerCompose::make('up', '-d', $services),
                 false
             );
         });

--- a/tests/Feature/StartTest.php
+++ b/tests/Feature/StartTest.php
@@ -13,7 +13,25 @@ class StartTest extends TestCase
 
         $this->artisan('start')->assertExitCode(0);
 
+        $this->assertDockerCompose('up -d '.env('FWD_START_DEFAULT_SERVICES'));
+    }
+
+    public function testStartWithAll()
+    {
+        $this->mockChecker();
+
+        $this->artisan('start --all')->assertExitCode(0);
+
         $this->assertDockerCompose('up -d');
+    }
+
+    public function testStartWithSpecificServices()
+    {
+        $this->mockChecker();
+
+        $this->artisan('start --services=chromedriver')->assertExitCode(0);
+
+        $this->assertDockerCompose('up -d chromedriver');
     }
 
     public function testStartOldVersionAllDependencies()

--- a/tests/Feature/StartTest.php
+++ b/tests/Feature/StartTest.php
@@ -13,7 +13,7 @@ class StartTest extends TestCase
 
         $this->artisan('start')->assertExitCode(0);
 
-        $this->assertDockerCompose('up -d '.env('FWD_START_DEFAULT_SERVICES'));
+        $this->assertDockerCompose('up -d ' . env('FWD_START_DEFAULT_SERVICES'));
     }
 
     public function testStartWithAll()


### PR DESCRIPTION
https://github.com/fireworkweb/fwd/issues/73

Breaking Change: `fwd start` will now by default start only services defined by FWD_START_DEFAULT_SERVICES environment variable to avoid starting any unnecessary services.