### PR TITLE
Fixing status command

### DIFF
--- a/app/Tasks/Status.php
+++ b/app/Tasks/Status.php
@@ -79,17 +79,17 @@ class Status extends Task
                 '--filter',
                 'ID=' . $id,
                 '--format',
-                Escaped::make('{{.Status}} : {{.Ports}}')
+                Escaped::make('{{.Status}} | {{.Ports}}')
             ));
 
-            if (empty($ps) || mb_strpos($ps, ':') === false) {
+            if (empty($ps) || mb_strpos($ps, '|') === false) {
                 throw new RuntimeException('could not fetch docker ps status of container with ID: ' . $id);
             }
 
             [
                 $info['state'],
                 $info['ports'],
-            ] = array_map('trim', explode(':', $ps));
+            ] = array_map('trim', explode('|', $ps));
         }
 
         return $isRunning;


### PR DESCRIPTION
Related to #115 

I've changed the exploding symbol separator from `:` to `|` because the first one can be found in the port info, for example `0.0.0.0:80->80/tcp`, so `explode(..)` wasn't getting the correct data.

<img width="463" alt="Screen Shot 2020-03-13 at 22 38 11" src="https://user-images.githubusercontent.com/25229545/76672519-1facf480-657c-11ea-94ec-be93fd693dd9.png">

Now, with `|` as the separator

<img width="664" alt="Screen Shot 2020-03-13 at 22 38 30" src="https://user-images.githubusercontent.com/25229545/76672530-3b17ff80-657c-11ea-8034-cb93c3448621.png">