### PR TITLE
Adding --laravel to install command

### DIFF
--- a/app/Commands/Install.php
+++ b/app/Commands/Install.php
@@ -3,6 +3,7 @@
 namespace App\Commands;
 
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 
 class Install extends Command
@@ -13,7 +14,7 @@ class Install extends Command
      * @var string
      */
     protected $signature = 'install
-                                {--laravel : Enable config optimizations to laravel (sync .env) }
+                                {--preset= : Preset with optimizations (laravel)}
                                 {--f|force : Overwrites project files (docker-compose.yml and .fwd)}
                                 {--docker-compose-version=3.7 : Which Docker Compose file version to use. Default is 3.7}';
 
@@ -72,9 +73,7 @@ class Install extends Command
             $this->warn('File "docker-compose.yml" already exists, skipping. (to override run again with --force)');
         }
 
-        if ($this->option('laravel')) {
-            $this->laravel();
-        }
+        $this->preset();
     }
 
     private function commentsOutAllVariables(string $env): string
@@ -113,7 +112,20 @@ class Install extends Command
         }
     }
 
-    private function laravel()
+    private function preset()
+    {
+        if (! $preset = $this->option('preset')) {
+            return;
+        }
+
+        $method = Str::camel("preset-{$preset}");
+
+        if (method_exists($this, $method)) {
+            $this->{$method}();
+        }
+    }
+
+    private function presetLaravel()
     {
         if (! File::exists($this->environment->getContextEnv('.env'))) {
             File::copy(

--- a/app/Commands/Install.php
+++ b/app/Commands/Install.php
@@ -13,6 +13,7 @@ class Install extends Command
      * @var string
      */
     protected $signature = 'install
+                                {--laravel : Enable config optimizations to laravel (sync .env) }
                                 {--f|force : Overwrites project files (docker-compose.yml and .fwd)}
                                 {--docker-compose-version=3.7 : Which Docker Compose file version to use. Default is 3.7}';
 
@@ -34,48 +35,46 @@ class Install extends Command
 
         $this->validateDockerComposeFileVersion($dockerComposeFileVersion);
 
-        if (! $this->option('force')) {
-            if (File::exists($this->environment->getContextDockerCompose())) {
-                $this->error('File "docker-compose.yml" already exists. (use -f to override)');
+        if ($this->option('force') || ! File::exists($this->environment->getContextEnv('.fwd'))) {
+            $localEnv = $this->uncommentsLocalVariables(
+                $this->commentsOutAllVariables(
+                    File::get($this->environment->getDefaultFwd())
+                )
+            );
 
-                return;
+            $put = File::put($this->environment->getContextEnv('.fwd'), $localEnv);
+
+            if (false === $put) {
+                $this->error('Failed to write local ".fwd" file.');
+
+                return 1;
             }
 
-            if (File::exists($this->environment->getContextEnv('.fwd'))) {
-                $this->error('File ".fwd" already exists. (use -f to override)');
+            $this->info('File ".fwd" copied.');
+        } else {
+            $this->warn('File ".fwd" already exists, skipping. (to override run again with --force)');
+        }
 
-                return;
+        if ($this->option('force') || ! File::exists($this->environment->getContextDockerCompose())) {
+            $copied = File::copy(
+                $this->environment->getDefaultDockerCompose($dockerComposeFileVersion),
+                $this->environment->getContextDockerCompose()
+            );
+
+            if (false === $copied) {
+                $this->error('Failed to write local "docker-compose.yml" file.');
+
+                return 1;
             }
+
+            $this->info('File "docker-compose.yml" copied.');
+        } else {
+            $this->warn('File "docker-compose.yml" already exists, skipping. (to override run again with --force)');
         }
 
-        $localEnv = $this->uncommentsLocalVariables(
-            $this->commentsOutAllVariables(
-                File::get($this->environment->getDefaultFwd())
-            )
-        );
-
-        $put = File::put($this->environment->getContextEnv('.fwd'), $localEnv);
-
-        if (false === $put) {
-            $this->error('Failed to write local ".fwd" file.');
-
-            return 1;
+        if ($this->option('laravel')) {
+            $this->laravel();
         }
-
-        $this->info('File ".fwd" copied.');
-
-        $copied = File::copy(
-            $this->environment->getDefaultDockerCompose($dockerComposeFileVersion),
-            $this->environment->getContextDockerCompose()
-        );
-
-        if (false === $copied) {
-            $this->error('Failed to write local "docker-compose.yml" file.');
-
-            return 1;
-        }
-
-        $this->info('File "docker-compose.yml" copied.');
     }
 
     private function commentsOutAllVariables(string $env): string
@@ -112,5 +111,43 @@ class Install extends Command
         if ($dockerComposeFileVersion !== '3.7') {
             $this->warn('Deprecated: not using the latest docker-compose-version=3.7 is deprecated and soon will lose support.');
         }
+    }
+
+    private function laravel()
+    {
+        if (! File::exists($this->environment->getContextEnv('.env'))) {
+            File::copy(
+                $this->environment->getContextEnv('.env.example'),
+                $this->environment->getContextEnv('.env')
+            );
+        }
+
+        $env = File::get($this->environment->getContextEnv('.env'));
+
+        $replace = [
+            'DB_HOST' => 'database',
+            'DB_DATABASE' => env('DB_DATABASE'),
+            'DB_USERNAME' => env('DB_USERNAME'),
+            'DB_PASSWORD' => env('DB_PASSWORD'),
+            'CACHE_DRIVER' => 'redis',
+            'QUEUE_CONNECTION' => 'redis',
+            'QUEUE_DRIVER' => 'redis', // compatibility to laravel < 5.7
+            'SESSION_DRIVER' => 'redis',
+            'REDIS_HOST' => 'cache',
+        ];
+
+        foreach ($replace as $variable => $value) {
+            $env = preg_replace("/^({$variable})=(.*)$/m", "$1={$value}", $env);
+        }
+
+        $put = File::put($this->environment->getContextEnv('.env'), $env);
+
+        if (false === $put) {
+            $this->error('Failed to write local ".env" file.');
+
+            return 1;
+        }
+
+        $this->info('File ".env" updated.');
     }
 }

--- a/tests/Feature/InstallTest.php
+++ b/tests/Feature/InstallTest.php
@@ -56,18 +56,18 @@ class InstallTest extends TestCase
         $this->assertCommandCalled('install');
     }
 
-    public function testLaravel()
+    public function testPresetLaravel()
     {
         $this->mockFwd();
         $this->mockDockerCompose();
         $this->mockLaravel();
 
-        $this->artisan('install --laravel')
+        $this->artisan('install --preset=laravel')
             ->expectsOutput('File ".fwd" copied.')
             ->expectsOutput('File "docker-compose.yml" copied.')
             ->expectsOutput('File ".env" updated.');
 
-        $this->assertCommandCalled('install --laravel');
+        $this->assertCommandCalled('install --preset=laravel');
     }
 
     public function testForce()


### PR DESCRIPTION
This introduces us to adding helpers/templates.

Right now laravel is kind of the default one but i wanted to make it verbose, so now `fwd install --laravel` will copy `.fwd`, `docker-compose.yml` and update `.env` properly to make it work out of the box.