### PR TITLE
Add env variable for check on start

### DIFF
--- a/.fwd
+++ b/.fwd
@@ -42,6 +42,8 @@ FWD_SSH_KEY_PATH="$HOME/.ssh/id_rsa"
 FWD_CONTEXT_PATH="$PWD"
 FWD_CUSTOM_PATH="$PWD/fwd"
 
+# Start configuration
+FWD_START_CHECK=true
 FWD_START_DEFAULT_SERVICES="database cache app http"
 
 # Database

--- a/app/Tasks/Start.php
+++ b/app/Tasks/Start.php
@@ -26,7 +26,7 @@ class Start extends Task
             [$this, 'startContainers'],
         ];
 
-        if ($this->checks) {
+        if ($this->checks && env('FWD_START_CHECK')) {
             array_unshift($tasks, [$this, 'checkDependencies']);
             $tasks[] = [$this, 'checkDatabase'];
         }


### PR DESCRIPTION
This adds a new way to enable/disable checks. It is useful, in a project without database (eg front only), to change on `.fwd` and not checking the database on start.

![image](https://user-images.githubusercontent.com/11093090/77098131-a2a4d380-69f0-11ea-9720-241b280f4497.png)
