### PR TITLE
Improve Gitlab CI files

### DIFF
--- a/gitlab-ci/assets.yml
+++ b/gitlab-ci/assets.yml
@@ -1,26 +1,25 @@
 .assets:
   stage: build
-  image:
-    name: fireworkweb/node:alpine
-    entrypoint: [""]
+  image: fireworkweb/fwd:1.0-rc
+  services:
+    - docker:dind
   tags:
-    - docker
+    - dind
   cache:
     paths:
       - node_modules/
       - .yarn/
   before_script:
     - mkdir -p .yarn
-    - yarn install --no-progress --silent --force --cache-folder=.yarn/
+    - fwd yarn install --no-progress --silent --force --cache-folder=.yarn/
   script:
-    - yarn run production
+    - fwd yarn production
   artifacts:
     paths:
       - public/js
       - public/css
       - public/img
       - public/mix-manifest.json
+      - node_modules
     expire_in: 1 week
-  variables:
-    GIT_STRATEGY: fetch
   dependencies: []

--- a/gitlab-ci/base.yml
+++ b/gitlab-ci/base.yml
@@ -20,12 +20,15 @@ include:
   - https://raw.githubusercontent.com/fireworkweb/fwd/1.0-rc/gitlab-ci/dusk.yml
   - https://raw.githubusercontent.com/fireworkweb/fwd/1.0-rc/gitlab-ci/phpunit.yml
 
+# build
 vendor:
   extends: .vendor
 
 assets:
   extends: .assets
+# build
 
+# QA
 eslint:
   extends: .eslint
 
@@ -46,9 +49,12 @@ phpcpd:
 
 phan:
   extends: .phan
+# QA
 
+# test
 dusk:
   extends: .dusk
 
 phpunit:
   extends: .phpunit
+# test

--- a/gitlab-ci/base.yml
+++ b/gitlab-ci/base.yml
@@ -9,6 +9,7 @@ variables:
 
 include:
   - https://raw.githubusercontent.com/fireworkweb/fwd/1.0-rc/gitlab-ci/vendor.yml
+  # - https://raw.githubusercontent.com/fireworkweb/fwd/1.0-rc/gitlab-ci/vendor-with-private.yml
   - https://raw.githubusercontent.com/fireworkweb/fwd/1.0-rc/gitlab-ci/assets.yml
   - https://raw.githubusercontent.com/fireworkweb/fwd/1.0-rc/gitlab-ci/eslint.yml
   - https://raw.githubusercontent.com/fireworkweb/fwd/1.0-rc/gitlab-ci/phpmnd.yml
@@ -23,6 +24,11 @@ include:
 # build
 vendor:
   extends: .vendor
+
+# vendor:
+#   extends: .vendor-with-private
+#   variables:
+#     CUSTOM_HOST: gitlab.example.com
 
 assets:
   extends: .assets

--- a/gitlab-ci/base.yml
+++ b/gitlab-ci/base.yml
@@ -1,0 +1,54 @@
+stages:
+  - build
+  - QA
+  - test
+
+variables:
+  GIT_STRATEGY: fetch
+  FWD_COMPOSE_EXEC_FLAGS: -T
+
+include:
+  - https://raw.githubusercontent.com/fireworkweb/fwd/1.0-rc/gitlab-ci/vendor.yml
+  - https://raw.githubusercontent.com/fireworkweb/fwd/1.0-rc/gitlab-ci/assets.yml
+  - https://raw.githubusercontent.com/fireworkweb/fwd/1.0-rc/gitlab-ci/eslint.yml
+  - https://raw.githubusercontent.com/fireworkweb/fwd/1.0-rc/gitlab-ci/phpmnd.yml
+  - https://raw.githubusercontent.com/fireworkweb/fwd/1.0-rc/gitlab-ci/phpcpd.yml
+  - https://raw.githubusercontent.com/fireworkweb/fwd/1.0-rc/gitlab-ci/php-cs-fixer.yml
+  - https://raw.githubusercontent.com/fireworkweb/fwd/1.0-rc/gitlab-ci/phan.yml
+  - https://raw.githubusercontent.com/fireworkweb/fwd/1.0-rc/gitlab-ci/phpmd.yml
+  - https://raw.githubusercontent.com/fireworkweb/fwd/1.0-rc/gitlab-ci/security-check.yml
+  - https://raw.githubusercontent.com/fireworkweb/fwd/1.0-rc/gitlab-ci/dusk.yml
+  - https://raw.githubusercontent.com/fireworkweb/fwd/1.0-rc/gitlab-ci/phpunit.yml
+
+vendor:
+  extends: .vendor
+
+assets:
+  extends: .assets
+
+eslint:
+  extends: .eslint
+
+php-cs-fixer:
+  extends: .php-cs-fixer
+
+phpmd:
+  extends: .phpmd
+
+security-check:
+  extends: .security-check
+
+phpmnd:
+  extends: .phpmnd
+
+phpcpd:
+  extends: .phpcpd
+
+phan:
+  extends: .phan
+
+dusk:
+  extends: .dusk
+
+phpunit:
+  extends: .phpunit

--- a/gitlab-ci/dusk.yml
+++ b/gitlab-ci/dusk.yml
@@ -1,28 +1,16 @@
+include:
+  - https://raw.githubusercontent.com/fireworkweb/fwd/1.0-rc/gitlab-ci/testing-base.yml
+
 .dusk:
-  stage: test
-  image: fireworkweb/fwd
-  services:
-    - docker:dind
-  tags:
-    - dind
+  extends: .testing-base
   script:
-    - mv .env.dusk.local .env
-    - fwd up -d
-    - fwd artisan dusk
-  after_script:
-    - fwd logs http > storage/logs/nginx.log
-    - fwd logs app > storage/logs/php-fpm.log
-    - fwd down -v
+    - fwd dusk
   artifacts:
     paths:
-      - storage/logs/
+      - storage/logs
       - tests/Browser/screenshots
       - tests/Browser/console
     when: on_failure
     expire_in: 1 week
   variables:
-    GIT_STRATEGY: fetch
-    COMPOSE_EXEC_FLAGS: "-T"
-  dependencies:
-    - assets
-    - vendor
+    TESTING_ENV_FILE: .env.dusk.local

--- a/gitlab-ci/eslint.yml
+++ b/gitlab-ci/eslint.yml
@@ -1,16 +1,11 @@
 .eslint:
   stage: QA
-  image:
-    name: fireworkweb/node:alpine
-    entrypoint: [""]
+  image: fireworkweb/fwd:1.0-rc
+  services:
+    - docker:dind
   tags:
-    - docker
+    - dind
   script:
-    - yarn install
-    - yarn lint
-  cache:
-    paths:
-      - node_modules/
-  variables:
-    GIT_STRATEGY: fetch
-  dependencies: []
+    - fwd yarn lint
+  dependencies:
+    - assets

--- a/gitlab-ci/phan.yml
+++ b/gitlab-ci/phan.yml
@@ -1,12 +1,13 @@
 .phan:
   stage: QA
-  image: jakzal/phpqa:alpine
+  image: fireworkweb/fwd:1.0-rc
+  services:
+    - docker:dind
   tags:
-    - docker
-  script:
+    - dind
+  before_script:
     - cp .env.testing .env
-    - phan --color -p -l app -iy 5
-  variables:
-    GIT_STRATEGY: fetch
+  script:
+    - fwd phan --color -p -l app -iy 5
   dependencies:
    - vendor

--- a/gitlab-ci/php-cs-fixer.yml
+++ b/gitlab-ci/php-cs-fixer.yml
@@ -1,14 +1,14 @@
 .php-cs-fixer:
   stage: QA
-  image: jakzal/phpqa:alpine
+  image: fireworkweb/fwd:1.0-rc
+  services:
+    - docker:dind
   tags:
-    - docker
+    - dind
   script:
-    - php-cs-fixer fix app --format=txt --dry-run --diff --verbose
-    - php-cs-fixer fix tests --format=txt --dry-run --diff --verbose
-    - php-cs-fixer fix resources/lang --format=txt --dry-run --diff --verbose
-    - php-cs-fixer fix config --format=txt --dry-run --diff --verbose
-    - php-cs-fixer fix database --format=txt --dry-run --diff --verbose
-  variables:
-    GIT_STRATEGY: fetch
+    - fwd php-cs-fixer fix app --format=txt --dry-run --diff --verbose
+    - fwd php-cs-fixer fix tests --format=txt --dry-run --diff --verbose
+    - fwd php-cs-fixer fix resources/lang --format=txt --dry-run --diff --verbose
+    - fwd php-cs-fixer fix config --format=txt --dry-run --diff --verbose
+    - fwd php-cs-fixer fix database --format=txt --dry-run --diff --verbose
   dependencies: []

--- a/gitlab-ci/phpcpd.yml
+++ b/gitlab-ci/phpcpd.yml
@@ -1,10 +1,10 @@
 .phpcpd:
   stage: QA
-  image: jakzal/phpqa:alpine
+  image: fireworkweb/fwd:1.0-rc
+  services:
+    - docker:dind
   tags:
-    - docker
+    - dind
   script:
-    - phpcpd --fuzzy app/
-  variables:
-    GIT_STRATEGY: fetch
+    - fwd phpcpd
   dependencies: []

--- a/gitlab-ci/phpmd.yml
+++ b/gitlab-ci/phpmd.yml
@@ -1,10 +1,10 @@
 .phpmd:
   stage: QA
-  image: jakzal/phpqa:alpine
+  image: fireworkweb/fwd:1.0-rc
+  services:
+    - docker:dind
   tags:
-    - docker
+    - dind
   script:
-    - phpmd app text phpmd/codesize.xml,phpmd/controversial.xml,phpmd/design.xml,phpmd/naming.xml,unusedcode,phpmd/cleancode.xml
-  variables:
-    GIT_STRATEGY: fetch
+    - fwd phpmd
   dependencies: []

--- a/gitlab-ci/phpmnd.yml
+++ b/gitlab-ci/phpmnd.yml
@@ -1,12 +1,10 @@
 .phpmnd:
   stage: QA
-  image: jakzal/phpqa:alpine
+  image: fireworkweb/fwd:1.0-rc
+  services:
+    - docker:dind
   tags:
-    - docker
+    - dind
   script:
-    - cp .env.testing .env
-    - phpmnd app/ --ignore-funcs=round,sleep,abort,strpad,number_format --exclude=tests --progress --extensions=default_parameter,-return,argument
-  variables:
-    GIT_STRATEGY: fetch
-  dependencies:
-    - vendor
+    - fwd phpmnd
+  dependencies: []

--- a/gitlab-ci/phpunit.yml
+++ b/gitlab-ci/phpunit.yml
@@ -1,24 +1,14 @@
+include:
+  - https://raw.githubusercontent.com/fireworkweb/fwd/1.0-rc/gitlab-ci/testing-base.yml
+
 .phpunit:
-  stage: test
-  image: fireworkweb/fwd
-  services:
-    - docker:dind
-  tags:
-    - dind
+  extends: .testing-base
   script:
-    - cp .env.testing .env
-    - fwd start
-    - fwd test --colors=never -vvv # --coverage-text
-  after_script:
-    - fwd down -v
+    - fwd phpunit --colors=never -vvv
   artifacts:
     paths:
-      - storage/logs/
+      - storage/logs
     when: on_failure
     expire_in: 1 week
   variables:
-    GIT_STRATEGY: fetch
-    COMPOSE_EXEC_FLAGS: "-T"
-  dependencies:
-    - assets
-    - vendor
+    TESTING_ENV_FILE: .env.testing

--- a/gitlab-ci/security-check.yml
+++ b/gitlab-ci/security-check.yml
@@ -1,10 +1,10 @@
 .security-check:
   stage: QA
-  image: jakzal/phpqa:alpine
+  image: fireworkweb/fwd:1.0-rc
+  services:
+    - docker:dind
   tags:
-    - docker
+    - dind
   script:
-    - security-checker security:check composer.lock
-  variables:
-    GIT_STRATEGY: fetch
+    - fwd php-security-checker
   dependencies: []

--- a/gitlab-ci/testing-base.yml
+++ b/gitlab-ci/testing-base.yml
@@ -1,0 +1,18 @@
+.testing-base:
+  stage: test
+  image: fireworkweb/fwd:1.0-rc
+  services:
+    - docker:dind
+  tags:
+    - dind
+  before_script:
+    - cp $TESTING_ENV_FILE .env
+    - fwd start
+    - fwd artisan migrate:fresh --seed
+  after_script:
+    - fwd docker-compose logs http > storage/logs/nginx.log
+    - fwd docker-compose logs app > storage/logs/php-fpm.log
+    - fwd docker-compose logs database > storage/logs/database.log
+    - fwd stop --purge
+  dependencies:
+    - vendor

--- a/gitlab-ci/vendor-with-private.yml
+++ b/gitlab-ci/vendor-with-private.yml
@@ -1,0 +1,22 @@
+include:
+  - https://raw.githubusercontent.com/fireworkweb/fwd/1.0-rc/gitlab-ci/vendor.yml
+
+.vendor-with-private:
+  extends: .vendor
+  before_script:
+    - cp .env.testing .env
+    - fwd start --services app --no-checks
+    - if [ -z "$SSH_KEY" ]; then
+        fwd docker-compose exec -T -e SSH_KEY="$SSH_KEY" app bash -c
+          "mkdir -p /root/.ssh
+          && chmod 700 /root/.ssh
+          && echo \"$SSH_KEY\" | tr -d '\r' > /root/.ssh/id_rsa
+          && chmod 600 /root/.ssh/id_rsa";
+      fi
+    - if [ -z "$CUSTOM_HOST" ]; then
+        fwd docker-compose exec -T -e CUSTOM_HOST="$CUSTOM_HOST" app bash -c
+          "mkdir -p /root/.ssh
+          && chmod 700 /root/.ssh
+          && ssh-keyscan -H $CUSTOM_HOST > /root/.ssh/known_hosts
+          && chmod 644 /root/.ssh/known_hosts";
+      fi

--- a/gitlab-ci/vendor.yml
+++ b/gitlab-ci/vendor.yml
@@ -1,20 +1,22 @@
 .vendor:
   stage: build
-  image:
-    name: fireworkweb/app:7.2-alpine
-    entrypoint: [""]
+  image: fireworkweb/fwd:1.0-rc
+  services:
+    - docker:dind
   tags:
-    - docker
+    - dind
   cache:
     paths:
       - vendor/
-  script:
+  before_script:
     - cp .env.testing .env
-    - composer install  --prefer-dist --no-progress --no-suggest --no-interaction -v --optimize-autoloader
+    - fwd start # @todo: being discussed at #128
+  script:
+    - fwd composer install --prefer-dist --no-progress --no-suggest --no-interaction -v --optimize-autoloader
+  after_script:
+    - fwd stop --purge
   artifacts:
     paths:
       - vendor
     expire_in: 1 hour
-  variables:
-    GIT_STRATEGY: fetch
   dependencies: []

--- a/gitlab-ci/vendor.yml
+++ b/gitlab-ci/vendor.yml
@@ -10,7 +10,7 @@
       - vendor/
   before_script:
     - cp .env.testing .env
-    - fwd start # @todo: being discussed at #128
+    - fwd start --services app --no-checks
   script:
     - fwd composer install --prefer-dist --no-progress --no-suggest --no-interaction -v --optimize-autoloader
   after_script:


### PR DESCRIPTION
I still have one point to discuss. 

I would recommend running all commands on `fwd` container, with `fwd` command. 
So it would use by default all containers defined on `.fwd` or `.env`, allowing developers to run the exact same command on the exact same container.