### PR TITLE
Escaping version format on docker version checker

### DIFF
--- a/app/Checker.php
+++ b/app/Checker.php
@@ -5,6 +5,7 @@ namespace App;
 use App\Builder\Builder;
 use App\Builder\Docker;
 use App\Builder\DockerCompose;
+use App\Builder\Escaped;
 
 class Checker
 {
@@ -33,7 +34,7 @@ class Checker
     {
         if (is_null($this->dockerVersion)) {
             $this->dockerVersion = $this->version(
-                Docker::make("version --format '{{.Server.Version}}'")
+                $this->dockerVersionCommandBuilder('{{.Server.Version}}')
             );
         }
 
@@ -44,7 +45,7 @@ class Checker
     {
         if (is_null($this->dockerApiVersion)) {
             $this->dockerApiVersion = $this->version(
-                Docker::make("version --format '{{.Server.APIVersion}}'")
+                $this->dockerVersionCommandBuilder('{{.Server.APIVersion}}')
             );
         }
 
@@ -97,6 +98,15 @@ class Checker
         );
 
         return $exitCode === 0;
+    }
+
+    protected function dockerVersionCommandBuilder(string $format): Builder
+    {
+        return Docker::make(
+            'version',
+            '--format',
+            Escaped::make($format)
+        );
     }
 
     protected function version(Builder $builder)

--- a/tests/Unit/CheckerTest.php
+++ b/tests/Unit/CheckerTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use App\Checker;
+use App\CommandExecutor;
+
+class CheckerTest extends TestCase
+{
+    public function testDockerVersion()
+    {
+        $this->mockCommandExecutorOutput(0, Checker::DOCKER_MIN_VERSION);
+
+        $checker = resolve(Checker::class);
+
+        $this->assertEquals($checker->dockerVersion(), Checker::DOCKER_MIN_VERSION);
+    }
+
+    public function testDockerApiVersion()
+    {
+        $this->mockCommandExecutorOutput(0, Checker::DOCKER_API_MIN_VERSION);
+
+        $checker = resolve(Checker::class);
+
+        $this->assertEquals($checker->dockerApiVersion(), Checker::DOCKER_API_MIN_VERSION);
+    }
+
+    public function testDockerComposeVersion()
+    {
+        $this->mockCommandExecutorOutput(0, Checker::DOCKER_COMPOSE_MIN_VERSION);
+
+        $checker = resolve(Checker::class);
+
+        $this->assertEquals($checker->dockerComposeVersion(), Checker::DOCKER_COMPOSE_MIN_VERSION);
+    }
+
+    public function testValidDockerVersion()
+    {
+        $this->mockCommandExecutorOutput(0, Checker::DOCKER_MIN_VERSION);
+
+        $checker = resolve(Checker::class);
+
+        $this->assertTrue($checker->checkDocker());
+    }
+
+    public function testInvalidDockerVersion()
+    {
+        $this->mockCommandExecutorOutput(0, '0.0.0');
+
+        $checker = resolve(Checker::class);
+
+        $this->assertFalse($checker->checkDocker());
+    }
+
+    public function testValidDockerApiVersion()
+    {
+        $this->mockCommandExecutorOutput(0, Checker::DOCKER_API_MIN_VERSION);
+
+        $checker = resolve(Checker::class);
+
+        $this->assertTrue($checker->checkDockerApi());
+    }
+
+    public function testInvalidDockerApiVersion()
+    {
+        $this->mockCommandExecutorOutput(0, '0.0.0');
+
+        $checker = resolve(Checker::class);
+
+        $this->assertFalse($checker->checkDockerApi());
+    }
+
+    public function testValidDockerComposeVersion()
+    {
+        $this->mockCommandExecutorOutput(0, Checker::DOCKER_COMPOSE_MIN_VERSION);
+
+        $checker = resolve(Checker::class);
+
+        $this->assertTrue($checker->checkDockerCompose());
+    }
+
+    public function testInvalidDockerComposeVersion()
+    {
+        $this->mockCommandExecutorOutput(0, '0.0.0');
+
+        $checker = resolve(Checker::class);
+
+        $this->assertFalse($checker->checkDockerCompose());
+    }
+
+    public function testErrorDockerVersionCommand()
+    {
+        $this->mockCommandExecutorOutput(1);
+
+        $checker = resolve(Checker::class);
+
+        $this->assertFalse($checker->checkDocker());
+    }
+
+    public function testErrorDockerApiVersionCommand()
+    {
+        $this->mockCommandExecutorOutput(1);
+
+        $checker = resolve(Checker::class);
+
+        $this->assertFalse($checker->checkDockerApi());
+    }
+
+    public function testErrorDockerComposeVersionCommand()
+    {
+        $this->mockCommandExecutorOutput(1);
+
+        $checker = resolve(Checker::class);
+
+        $this->assertFalse($checker->checkDockerCompose());
+    }
+
+    public function testDockerisRunning()
+    {
+        $this->mockCommandExecutorOutput(0);
+
+        $checker = resolve(Checker::class);
+
+        $this->assertTrue($checker->checkDockerIsRunning());
+    }
+
+    public function testDockerIsNotRunning()
+    {
+        $this->mockCommandExecutorOutput(0);
+
+        $checker = resolve(Checker::class);
+
+        $this->assertTrue($checker->checkDockerIsRunning());
+    }
+
+    protected function mockCommandExecutorOutput(int $exitCode, string $output = '')
+    {
+        $this->mock(CommandExecutor::class, function ($mock) use ($exitCode, $output) {
+            $mock->shouldReceive('runQuietly')
+                ->andReturn($exitCode);
+
+            $mock->shouldReceive('getOutputBuffer')
+                ->andReturn($output);
+        });
+    }
+}


### PR DESCRIPTION
@fabriciojs @dbpolito I'm trying to fix the bug we faced with start command on a WSL2 environment. I haven't tested it because I don't have a Windows environment here, but I'm suspecting that the bug's cause is the single quote inside the command to format docker version output. But even if this pull request doesn't fix the bug, it would be nice to be merged because is more safe if we escape quoted args...and I have added new tests.